### PR TITLE
Fix some warnings in cargo tomls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "php-rs"
+version = "0.1.0"
+dependencies = [
+ "evaluator",
+]
+
+[[package]]
 name = "phpl"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,13 @@
+[package]
+name = "php-rs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+evaluator = { path = "evaluator" }
+
 [workspace]
+resolver = "2"
 members = [
 	"phpl",
 	"evaluator",
@@ -9,3 +18,9 @@ opt-level = "s"
 lto = "thin"
 codegen-units = 1
 strip = true
+
+[[bin]]
+path = "phpl/src/main.rs"
+name = "phpl-rs"
+test = false
+bench = false

--- a/php-parser/Cargo.toml
+++ b/php-parser/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "php-parser-rs"
 version = "0.1.3"
+edition = "2021"
 authors = ["Ryan Chandler <https://github.com/ryangjchandler>"]
 
 [dependencies]


### PR DESCRIPTION
Adopt the warnings for Cargo.toml

```
alex@alex-tuxedoinfinitybooks1517gen7 on 10/10/2024 at 01:23:52_CEST /datadisk/git-repos/phpl $ cargo r ../pinf.php
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
warning: /datadisk/git-repos/phpl/php-parser/Cargo.toml: no edition set: defaulting to the 2015 edition while the latest is 2021
```